### PR TITLE
Adding an extra tag in the ecs module so that it displays in the right section for the templates

### DIFF
--- a/templates/ecs/template.yaml
+++ b/templates/ecs/template.yaml
@@ -11,6 +11,7 @@ metadata:
     - terraform
     - aws
     - ecs 
+    - add
 spec:
   owner: group:cds-snc/internal-sre
   type: service


### PR DESCRIPTION

# Summary | Résumé

Adding an extra tag so that the ECS module is move up to the Add Infrastructure section of templates as opposed to the Other templates section as it is currently below:

<img width="1329" alt="Screenshot 2024-04-19 at 11 01 54 AM" src="https://github.com/cds-snc/backstage-scaffolder-templates/assets/85905333/0ccb6f5c-fa0a-4c78-ade2-36895e94ba68">
