### PR TITLE
fix: invalid tag character

### DIFF
--- a/templates/hosted_zone/template.yaml
+++ b/templates/hosted_zone/template.yaml
@@ -10,7 +10,7 @@ metadata:
   tags:
     - terraform
     - aws
-    - hosted_zone 
+    - hosted-zone 
     - add
 spec:
   owner: group:cds-snc/internal-sre


### PR DESCRIPTION
# Summary | Résumé

There seems to be an issue with using underscore (`_`) character in tags. Changing to `-`