### PR TITLE
Restrict lambda invoke permissions to cloudfront

### DIFF
--- a/templates/lambda_container/README.md
+++ b/templates/lambda_container/README.md
@@ -53,15 +53,15 @@ Have these ready before running it:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `product_name` | ✅ | Product name; used to name the function (`<product_name>-lambda`) and the Terraform resources. |
-| `billing_code` | ✅ | Billing/cost-centre tag value. |
-| `ecr_repository_name` | ✅ | Name of the existing ECR repository. URL and ARN are derived from it. |
-| `ecr_tag` | ✅ | Image tag to deploy (e.g. `latest`). |
-| `cloudfront_distribution_id` | ✅ | ID of the existing CloudFront distribution allowed to invoke the function. |
+| `product_name` | Required | Product name; used to name the function (`<product_name>-lambda`) and the Terraform resources. |
+| `billing_code` | Required | Billing/cost-centre tag value. |
+| `ecr_repository_name` | Required | Name of the existing ECR repository. URL and ARN are derived from it. |
+| `ecr_tag` | Required | Image tag to deploy (e.g. `latest`). |
+| `cloudfront_distribution_id` | Required | ID of the existing CloudFront distribution allowed to invoke the function. |
 | `memory` | optional | Function memory in MB (module default `128`). |
 | `timeout` | optional | Function timeout in seconds (module default `3`, max `900`). |
-| `repoUrl` | ✅ | Target GitHub repo (cds-snc) where the PR is opened. |
-| `terraformLoc` | ✅ | Directory the Terraform is written into, e.g. `terragrunt/aws/`. Files land in `<terraformLoc>/lambda/`. |
+| `repoUrl` | Required | Target GitHub repo (cds-snc) where the PR is opened. |
+| `terraformLoc` | Required | Directory the Terraform is written into, e.g. `terragrunt/aws/`. Files land in `<terraformLoc>/lambda/`. |
 
 ## How to use
 

--- a/templates/lambda_container/README.md
+++ b/templates/lambda_container/README.md
@@ -1,0 +1,80 @@
+# Lambda container image function (Backstage template)
+
+Backstage software template that scaffolds the Terraform for an AWS Lambda function
+deployed from a container image in ECR, fronted by CloudFront.
+
+It wraps the CDS [`terraform-modules//lambda`](https://github.com/cds-snc/terraform-modules/tree/main/lambda)
+module and opens the PR for you. The template only produces a Terraform fragment — it is
+designed to be merged into an existing Terraform/Terragrunt environment, not to stand on its own.
+
+## What it creates
+
+Files are written into `<terraformLoc>/lambda/` in the target repo:
+
+| File | Contents |
+|------|----------|
+| `lambda.tf` | The `lambda` module, a `latest` alias, the function URL, and the invoke permissions. Also derives the ECR URL/ARN from the repository name. |
+| `output.tf` | `function_arn`, `function_name`, `invoke_arn`, `function_url`. |
+
+Resources provisioned:
+
+- Lambda function (container image) via the CDS `lambda` module, with Lambda Insights enabled.
+- `aws_lambda_alias` `latest`. 
+- `aws_lambda_function_url` with `authorization_type = "NONE"`.
+- Two `aws_lambda_permission` resources that restrict invocation to CloudFront only, scoped
+  to a specific distribution in the current account.
+
+## Requirements
+
+This template assumes the following already exist / are provided by the surrounding environment.
+Have these ready before running it:
+
+1. An existing ECR repository holding the container image.
+   - You supply its name in the form. The URL and ARN are constructed automatically as:
+     - URL — `<account_id>.dkr.ecr.<region>.amazonaws.com/<name>`
+     - ARN — `arn:aws:ecr:<region>:<account_id>:repository/<name>`
+   - The name is not validated — a wrong name produces a URL/ARN that points at nothing, and
+     the Lambda will fail to pull the image at runtime. Double-check it.
+   - For ECRs created with the [ECR template](../ecr).
+   - An image must be pushed to the repository at the tag you specify.
+
+2. An existing CloudFront distribution.
+   - You supply its distribution ID in the form (e.g. `E1A2B3C4D5E6F7`).
+   - Invocation of the function URL is locked to this distribution
+     (`principal = "cloudfront.amazonaws.com"` + a `source_arn` scoped to it). Anyone hitting the
+     function URL directly is denied — traffic must come through CloudFront.
+   - Because the ID is required up front, the distribution must exist *before* scaffolding. If you
+     create the distribution and the Lambda in the same change, scaffold the distribution first.
+
+3. A Terraform/Terragrunt environment to merge into, providing:
+   - The AWS provider and remote state/backend config — this template ships neither.
+
+## Inputs (form fields)
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `product_name` | ✅ | Product name; used to name the function (`<product_name>-lambda`) and the Terraform resources. |
+| `billing_code` | ✅ | Billing/cost-centre tag value. |
+| `ecr_repository_name` | ✅ | Name of the existing ECR repository. URL and ARN are derived from it. |
+| `ecr_tag` | ✅ | Image tag to deploy (e.g. `latest`). |
+| `cloudfront_distribution_id` | ✅ | ID of the existing CloudFront distribution allowed to invoke the function. |
+| `memory` | optional | Function memory in MB (module default `128`). |
+| `timeout` | optional | Function timeout in seconds (module default `3`, max `900`). |
+| `repoUrl` | ✅ | Target GitHub repo (cds-snc) where the PR is opened. |
+| `terraformLoc` | ✅ | Directory the Terraform is written into, e.g. `terragrunt/aws/`. Files land in `<terraformLoc>/lambda/`. |
+
+## How to use
+
+1. In Backstage, open Create… → "Create an Lambda container image function instance".
+2. Fill in the form. Make sure the ECR repository, the pushed image, and the CloudFront distribution
+   from [Requirements](#requirements) already exist.
+3. Submit. The template opens a pull request titled
+   `🥡 Create AWS lambda function with Container image for <product_name>` against the chosen repo,
+   on branch `backstage_template_<product_name>_lambda`.
+4. Review and complete the PR before merging.
+5. Merge, then `terraform`/`terragrunt apply` through your normal pipeline.
+
+## References
+
+- CDS Lambda module: <https://github.com/cds-snc/terraform-modules/tree/main/lambda>
+- Companion ECR template: [`templates/ecr`](../ecr)

--- a/templates/lambda_container/content/inputs.tf
+++ b/templates/lambda_container/content/inputs.tf
@@ -1,9 +1,0 @@
-variable "ecr_repository_url" {
-    description = "URL of the Doc_to_html ECR"
-    type        = string
-  }
-  
-variable "ecr_repository_arn" {
-    description = "Arn of the Doc_to_html ECR Repository"
-    type        = string
-  }

--- a/templates/lambda_container/content/lambda.tf
+++ b/templates/lambda_container/content/lambda.tf
@@ -2,9 +2,9 @@ module "${{ values.product_name }}_lambda" {
     source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v9.4.4"
     name                   = "${{ values.product_name }}-lambda"
     billing_tag_value      = ${{ values.billing_code | dump }}
-    ecr_arn                = var.ecr_repository_arn
+    ecr_arn                = local.ecr_repository_arn
     enable_lambda_insights = true
-    image_uri              = "${var.ecr_repository_url}:${{ values.ecr_tag }}"
+    image_uri              = "${local.ecr_repository_url}:${{ values.ecr_tag }}"
     memory                 = ${{ values.memory }} 
     timeout                = ${{ values.timeout }} 
   }
@@ -22,6 +22,16 @@ resource "aws_lambda_alias" "${{ values.product_name }}_lambda_alias" {
     }
   }
   
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+    ecr_repository_name = "${{ values.ecr_repository_name }}"
+    ecr_repository_url  = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/${local.ecr_repository_name}"
+    ecr_repository_arn  = "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${local.ecr_repository_name}"
+}
+
 resource "aws_lambda_function_url" "${{ values.product_name }}_lambda_url" {
     function_name      = module.${{ values.product_name }}_lambda.function_name
     qualifier          = aws_lambda_alias.${{ values.product_name }}_lambda_alias.name
@@ -34,12 +44,14 @@ resource "aws_lambda_permission" "${{ values.product_name }}_invoke_function_url
     action                 = "lambda:InvokeFunctionUrl"
     function_name          = module.${{ values.product_name }}_lambda.function_name
     function_url_auth_type = "NONE"
-    principal              = "*"
+    principal              = "cloudfront.amazonaws.com"
+    source_arn             = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${{ values.cloudfront_distribution_id }}"
 }
 
 resource "aws_lambda_permission" "${{ values.product_name }}_invoke_function" {
   statement_id  = "AllowInvokeFunction"
   action        = "lambda:InvokeFunction"
   function_name = module.${{ values.product_name }}_lambda.function_name
-  principal     = "*"
+  principal     = "cloudfront.amazonaws.com"
+  source_arn    = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/${{ values.cloudfront_distribution_id }}"
 }

--- a/templates/lambda_container/template.yaml
+++ b/templates/lambda_container/template.yaml
@@ -21,23 +21,35 @@ spec:
   parameters:
     - title: Fill in the lambda Details
       required:
-        - product_name 
-        - billing_code 
-        - ecr_tag  
+        - product_name
+        - billing_code
+        - ecr_repository_name
+        - ecr_tag
+        - cloudfront_distribution_id
       properties:
         product_name:
           title: What is the product name that you are creating the lambda for?
           type: string 
           description: The product name for the product for which you are creating the lambda function for . Required.
         billing_code:
-          title: Billing code 
+          title: Billing code
           type: string
-          description: The billing code to associate with the lambda function. 
+          description: The billing code to associate with the lambda function.
+        ecr_repository_name:
+          title: ECR repository name
+          type: string
+          description: The name of the existing ECR repository holding the container image. The repository URL and ARN are constructed from this name. Required.
+          ui:help: "Hint: For ECRs created with the ECR template this is <product_name>_ecr, for example doc_to_html_ecr."
         ecr_tag:
-          title: ECR Tag 
-          type: string 
+          title: ECR Tag
+          type: string
           description: The tag of the ECR Image. Required.
-          ui:help: "Hint: For example latest" 
+          ui:help: "Hint: For example latest"
+        cloudfront_distribution_id:
+          title: CloudFront distribution ID
+          type: string
+          description: The ID of the CloudFront distribution allowed to invoke this Lambda function URL. Required.
+          ui:help: "Hint: For example E1A2B3C4D5E6F7. Found in the CloudFront console or as the 'id' output of the distribution's terraform."
         memory:
           title: Memory of the lambda function 
           type: string 
@@ -85,7 +97,9 @@ spec:
         values:
           product_name: ${{ parameters.product_name }}
           billing_code: ${{ parameters.billing_code }}
+          ecr_repository_name: ${{ parameters.ecr_repository_name }}
           ecr_tag: ${{ parameters.ecr_tag }}
+          cloudfront_distribution_id: ${{ parameters.cloudfront_distribution_id }}
           memory: ${{ parameters.memory }}
           timeout: ${{ parameters.timeout }}
           repoUrl: "github.com/cds-snc/${{ parameters.repoUrl }}"
@@ -100,6 +114,8 @@ spec:
          "Lambda container function has been added to ${{ parameters.repoUrl }} with the following settings:"
           product_name: ${{ parameters.product_name }}
           billing_code: ${{ parameters.billing_code }}
+          ecr_repository_name: ${{ parameters.ecr_repository_name }}
+          cloudfront_distribution_id: ${{ parameters.cloudfront_distribution_id }}
           memory: ${{ parameters.memory }}
           timeout: ${{ parameters.timeout }}
           repoUrl: "github.com/cds-snc/${{ parameters.repoUrl }}"


### PR DESCRIPTION
# Summary | Résumé

Restricts the scaffolded Lambda function URL to CloudFront only and removes the dangling ECR inputs. Also added a README on usage. 